### PR TITLE
chore: improve UX for metadata edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The application features a flexible 3-pane layout with resizable borders:
     2. **Set Marker** (image → red pin): Set active marker from selected image GPS coordinates
     3. **🌍🔍 Reverse Geocoding** (toggle): Auto-determine country and city from GPS coordinates
     4. **Set Taken Date** (file → calendar): Initialize Taken Date from file creation date
-    5. **Set GPS Date** (calendar → GPS): Initialize GPS Date from Taken Date
+    5. **Set GPS Date** (calendar → GPS): Initialize GPS Date from Taken Date (converted to UTC)
     6. **Repair Metadata** (medical cross): Fix/repair metadata using ExifTool
   - Leaflet-based map with OpenStreetMap tiles
   - Scale control
@@ -173,8 +173,12 @@ All three panes can be resized by dragging the borders between them.
 **Image List:**
 - **Left Click**: Select an image to view it in the bottom-left panel. Selected images are highlighted in blue on the map
 - **Multi-Select**: Use Ctrl/Cmd + Click or Shift + Click to select multiple images. The first image will be displayed in the viewer
-- **Right Click**: Open context menu with "Edit metadata" option
-- **Double-Click Cell**: Edit metadata directly in the table (country uses dropdown picker, dates use date picker)
+- **Right Click**: Open context menu with:
+  - "Edit Metadata" - Opens full metadata editor dialog (works for single or multiple selections)
+  - "Quick Edit (Basic Fields)" - Opens simplified batch editor for common fields (only appears when 2+ images selected)
+- **Double-Click Cell**:
+  - Filename cell: Opens Edit Metadata dialog
+  - other cells: Edit metadata directly in the table (country uses dropdown picker, dates use date picker)
 - **Delete/Backspace**: Clear cell values (deletes corresponding metadata tags)
 - **Rename Files**: Use File → Rename Photos for pattern-based batch renaming
 
@@ -183,7 +187,6 @@ All three panes can be resized by dragging the borders between them.
 - **Click on Marker**: View popup with image thumbnail and filename
 - **Select Image**: Centers map on selected image's marker, preserving current zoom level
 - **Deselect All**: Fits map bounds to show all markers
-- **Update GPS Button**: Update GPS coordinates of selected images with the active marker position
 
 **AI Tools Menu:**
 - **Find Similar Photos**: Analyze all loaded images to find similar/duplicate photos
@@ -201,14 +204,6 @@ All three panes can be resized by dragging the borders between them.
   - Similarity threshold slider (0.0-1.0)
   - Model cache directory selection
   - Reset to defaults option
-  - If reverse geocoding is enabled (🌍🔍 toggled on), automatically lookup country and city
-  - Shows dialog to review/edit location before applying
-  - Updates keywords with country code and country name
-- **Set Marker Button**: Set the active marker from the selected image's GPS coordinates (enabled only when one image with GPS is selected)
-- **Reverse Geocoding Toggle** (🌍🔍): Enable/disable automatic location lookup from coordinates
-- **Set Taken Date Button**: Initialize Taken Date from file creation date for selected images
-- **Set GPS Date Button**: Initialize GPS Date from Taken Date (converted to UTC) for selected images
-- **Repair Metadata Button**: Run ExifTool repair on selected images
 
 **Panes:**
 - **Resize Panes**: Drag the borders between panes to adjust their sizes
@@ -343,6 +338,8 @@ The application writes to multiple metadata standards for maximum compatibility:
 - Select multiple images to apply changes to all at once
 - Use Ctrl/Cmd+Click for non-contiguous selection
 - Use Shift+Click for range selection
+- **Edit Metadata**: Full metadata editor works with multiple images - changes apply to all selected
+- **Quick Edit**: Right-click menu option for batch editing of common fields (TZ Offset, Country, City, Headline) when 2+ images are selected
 - Empty values won't overwrite existing metadata
 
 ### AI Features

--- a/geosetter_lite/ui/__init__.py
+++ b/geosetter_lite/ui/__init__.py
@@ -4,7 +4,7 @@ from .main_window import MainWindow
 from .map_panel import MapPanel
 from .map_widget import MapWidget
 from .metadata_editor import MetadataEditor
-from .batch_edit_dialog import BatchEditDialog
+from .quick_edit_dialog import QuickEditDialog
 from .geocoding_dialog import GeocodingDialog
 from .geolocation_dialog import GeolocationDialog
 from .similarity_dialog import SimilarityDialog
@@ -17,7 +17,7 @@ __all__ = [
     'MapPanel',
     'MapWidget',
     'MetadataEditor',
-    'BatchEditDialog',
+    'QuickEditDialog',
     'GeocodingDialog',
     'GeolocationDialog',
     'SimilarityDialog',

--- a/geosetter_lite/ui/map_panel.py
+++ b/geosetter_lite/ui/map_panel.py
@@ -13,7 +13,6 @@ class MapPanel(QWidget):
     # Signals
     update_coordinates_requested = Signal()  # Update selected images with active marker coords
     set_marker_from_selection_requested = Signal()  # Set active marker from selected image
-    batch_edit_requested = Signal()  # Batch edit metadata for multiple selected images
     repair_metadata_requested = Signal()  # Repair metadata for selected images
     set_taken_date_from_creation_requested = Signal()  # Set Taken Date from file creation date
     set_gps_date_from_taken_requested = Signal()  # Set GPS Date from Taken Date
@@ -32,9 +31,6 @@ class MapPanel(QWidget):
         
         # Create icon for "Set Marker" (image to marker)
         self.set_marker_icon = self._create_set_marker_icon()
-        
-        # Create icon for "Batch Edit"
-        self.batch_edit_icon = self._create_batch_edit_icon()
         
         # Create icon for "Repair Metadata"
         self.repair_icon = self._create_repair_icon()
@@ -135,49 +131,6 @@ class MapPanel(QWidget):
         painter.drawLine(37, 18, 37, 26)
         painter.drawLine(35, 24, 37, 26)
         painter.drawLine(39, 24, 37, 26)
-        
-        painter.end()
-        return QIcon(pixmap)
-    
-    def _create_batch_edit_icon(self) -> QIcon:
-        """Create icon for batch editing metadata"""
-        pixmap = QPixmap(48, 48)
-        pixmap.fill(Qt.GlobalColor.transparent)
-        
-        painter = QPainter(pixmap)
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        
-        # Draw multiple documents/images stacked
-        painter.setPen(QPen(QColor(50, 100, 200), 2.5))
-        painter.setBrush(QColor(100, 150, 255, 80))
-        
-        # Back document
-        painter.drawRect(18, 12, 16, 20)
-        
-        # Middle document
-        painter.setBrush(QColor(100, 150, 255, 120))
-        painter.drawRect(15, 14, 16, 20)
-        
-        # Front document
-        painter.setBrush(QColor(100, 150, 255))
-        painter.drawRect(12, 16, 16, 20)
-        
-        # Draw pencil/edit icon
-        painter.setPen(QPen(QColor(200, 120, 50), 2.5))
-        painter.setBrush(QColor(240, 160, 80))
-        
-        # Pencil body
-        painter.drawLine(30, 22, 38, 30)
-        painter.drawLine(28, 24, 36, 32)
-        
-        # Pencil tip
-        painter.setPen(QPen(QColor(100, 50, 20), 2))
-        painter.drawLine(30, 22, 28, 24)
-        
-        # Pencil eraser
-        painter.setPen(QPen(QColor(220, 80, 80), 2))
-        painter.drawPoint(38, 30)
-        painter.drawPoint(36, 32)
         
         painter.end()
         return QIcon(pixmap)
@@ -393,16 +346,12 @@ class MapPanel(QWidget):
         self.update_coords_action.triggered.connect(self.update_coordinates_requested.emit)
         toolbar.addAction(self.update_coords_action)
         
-        toolbar.addSeparator()
-        
         # Action: Set active marker from selected image
         self.set_marker_action = QAction(self.set_marker_icon, "Set Marker", self)
         self.set_marker_action.setToolTip("Set active marker from selected image GPS coordinates")
         self.set_marker_action.setEnabled(False)
         self.set_marker_action.triggered.connect(self.set_marker_from_selection_requested.emit)
         toolbar.addAction(self.set_marker_action)
-        
-        toolbar.addSeparator()
         
         # Reverse geocoding toggle action (third position)
         self.reverse_geocoding_action = QAction(self.reverse_geocoding_icon, "Auto Reverse Geocoding", self)
@@ -421,23 +370,12 @@ class MapPanel(QWidget):
         self.set_taken_date_action.triggered.connect(self.set_taken_date_from_creation_requested.emit)
         toolbar.addAction(self.set_taken_date_action)
         
-        toolbar.addSeparator()
-        
         # Action: Set GPS Date from Taken Date
         self.set_gps_date_action = QAction(self.set_gps_date_icon, "Set GPS Date", self)
         self.set_gps_date_action.setToolTip("Set GPS Date from Taken Date for selected images")
         self.set_gps_date_action.setEnabled(False)
         self.set_gps_date_action.triggered.connect(self.set_gps_date_from_taken_requested.emit)
         toolbar.addAction(self.set_gps_date_action)
-        
-        toolbar.addSeparator()
-        
-        # Action: Batch edit metadata for multiple selected images
-        self.batch_edit_action = QAction(self.batch_edit_icon, "Batch Edit", self)
-        self.batch_edit_action.setToolTip("Edit metadata for multiple selected images")
-        self.batch_edit_action.setEnabled(False)
-        self.batch_edit_action.triggered.connect(self.batch_edit_requested.emit)
-        toolbar.addAction(self.batch_edit_action)
         
         toolbar.addSeparator()
         
@@ -505,15 +443,6 @@ class MapPanel(QWidget):
             enabled: True to enable, False to disable
         """
         self.repair_action.setEnabled(enabled)
-    
-    def enable_batch_edit_action(self, enabled: bool):
-        """
-        Enable or disable the batch edit action
-        
-        Args:
-            enabled: True to enable, False to disable
-        """
-        self.batch_edit_action.setEnabled(enabled)
     
     def enable_set_taken_date_action(self, enabled: bool):
         """

--- a/geosetter_lite/ui/quick_edit_dialog.py
+++ b/geosetter_lite/ui/quick_edit_dialog.py
@@ -1,5 +1,5 @@
 """
-Batch Metadata Edit Dialog - Edit metadata for multiple images
+Quick Metadata Edit Dialog - Edit metadata for multiple images
 """
 from typing import Dict, Any, Optional
 from datetime import datetime
@@ -81,12 +81,12 @@ class SimpleTZOffsetDelegate(QStyledItemDelegate):
         return "+00:00"
 
 
-class BatchEditDialog(QDialog):
-    """Dialog for batch editing metadata of multiple images"""
+class QuickEditDialog(QDialog):
+    """Dialog for quick editing metadata of multiple images"""
     
     def __init__(self, num_images: int, parent=None):
         """
-        Initialize the batch edit dialog
+        Initialize the quick edit dialog
         
         Args:
             num_images: Number of images to be edited
@@ -95,7 +95,7 @@ class BatchEditDialog(QDialog):
         super().__init__(parent)
         self.num_images = num_images
         
-        self.setWindowTitle("Batch Metadata Edit")
+        self.setWindowTitle("Quick Metadata Edit")
         self.setMinimumSize(600, 400)
         self.setModal(True)
         


### PR DESCRIPTION
This pull request refines the batch metadata editing feature by replacing the previous "Batch Edit" dialog and toolbar action with a new "Quick Edit" dialog, accessible via the context menu for multiple selections. The UI and documentation have been updated to reflect this streamlined workflow, removing the batch edit toolbar button and clarifying editing options. The changes improve usability for editing common fields across multiple images.

**User Interface and Workflow Improvements:**

* The "Batch Edit" toolbar button and its supporting code have been removed from `MapPanel`, simplifying the toolbar and reducing clutter. Batch editing is now accessed via the right-click context menu in the image list. [[1]](diffhunk://#diff-bfd25eec433f9054d61f09cf6c8337007000cecc56b266f81047f1ce64998424L36-L38) [[2]](diffhunk://#diff-bfd25eec433f9054d61f09cf6c8337007000cecc56b266f81047f1ce64998424L396-L406) [[3]](diffhunk://#diff-bfd25eec433f9054d61f09cf6c8337007000cecc56b266f81047f1ce64998424L435-L443) [[4]](diffhunk://#diff-bfd25eec433f9054d61f09cf6c8337007000cecc56b266f81047f1ce64998424L509-L517) [[5]](diffhunk://#diff-bfd25eec433f9054d61f09cf6c8337007000cecc56b266f81047f1ce64998424L142-L184) [[6]](diffhunk://#diff-bfd25eec433f9054d61f09cf6c8337007000cecc56b266f81047f1ce64998424L16) [[7]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L487-L489) [[8]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L498) [[9]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L231)
* The context menu in the image list now includes "Quick Edit (Basic Fields)" when two or more images are selected, launching the new dialog for editing common metadata fields in bulk. [[1]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L824-R844) [[2]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L996-R1018) [[3]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L1020-R1035)
* Double-clicking the filename cell in the table opens the full metadata editor, while other cells remain directly editable inline. [[1]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18R157) [[2]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L824-R844)

**Dialog Refactoring:**

* The former `BatchEditDialog` has been renamed and refactored to `QuickEditDialog`, with corresponding updates throughout the codebase to use the new class and dialog title. [[1]](diffhunk://#diff-cb1c54a9636529d268a427d506932d91a647c4cf0182a20033c0f912701cf19eL7-R7) [[2]](diffhunk://#diff-cb1c54a9636529d268a427d506932d91a647c4cf0182a20033c0f912701cf19eL20-R20) [[3]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L996-R1018) [[4]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L1020-R1035) [[5]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18R157) [[6]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L824-R844) [[7]](diffhunk://#diff-cd0e171ba8ba4789d25ec30dccf0c80e9c8e945058c862cc3924c891f298609bL2-R2) [[8]](diffhunk://#diff-cd0e171ba8ba4789d25ec30dccf0c80e9c8e945058c862cc3924c891f298609bL84-R89) [[9]](diffhunk://#diff-cd0e171ba8ba4789d25ec30dccf0c80e9c8e945058c862cc3924c891f298609bL98-R98) [[10]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18R157) [[11]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L996-R1018) [[12]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L1020-R1035)

**Documentation Updates:**

* The `README.md` has been updated to clarify the new editing workflow: batch editing is now "Quick Edit" via the context menu, and the toolbar no longer includes a batch edit button. The documentation also clarifies context menu options and double-click behavior in the image list. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L162-R162) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L176-R181) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L204-L211) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R341-R342)

These changes streamline the user experience for editing metadata on multiple images and reduce UI complexity by removing the redundant toolbar action, making the workflow more intuitive and focused.