### PR TITLE
feat: add directory browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ init: ## Init or resync development environment
 clean: ## Remove build and temporary files
 	rm -rf dist/*
 
-run: init ## Run application
-	uv run python main.py
+run: init ## Run application (use ARGS="..." to pass arguments)
+	uv run python main.py $(ARGS)
 
 package: clean init ## Generate Python wheel and macOS App bundle
 	echo "Building Python wheel..."

--- a/geosetter_lite.spec
+++ b/geosetter_lite.spec
@@ -55,6 +55,7 @@ a = Analysis(
         'geosetter_lite.ui.rename_dialog',
         'geosetter_lite.ui.table_delegates',
         'geosetter_lite.ui.error_dialog',
+        'geosetter_lite.ui.directory_toolbar',
         # Services
         'geosetter_lite.services',
         'geosetter_lite.services.exiftool_service',

--- a/geosetter_lite/ui/__init__.py
+++ b/geosetter_lite/ui/__init__.py
@@ -12,6 +12,7 @@ from .settings_dialog import SettingsDialog
 from .progress_dialog import ProgressDialog
 from .error_dialog import ErrorDialog, show_exiftool_error
 from .table_delegates import CountryDelegate, DateTimeDelegate, TZOffsetDelegate
+from .directory_toolbar import DirectoryToolbar
 
 __all__ = [
     'MainWindow',
@@ -29,4 +30,5 @@ __all__ = [
     'CountryDelegate',
     'DateTimeDelegate',
     'TZOffsetDelegate',
+    'DirectoryToolbar',
 ]

--- a/geosetter_lite/ui/directory_toolbar.py
+++ b/geosetter_lite/ui/directory_toolbar.py
@@ -1,0 +1,80 @@
+"""
+Directory Toolbar - Browse and select directories
+"""
+from pathlib import Path
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QLineEdit, QPushButton, QFileDialog
+from PySide6.QtCore import Signal, Qt
+
+
+class DirectoryToolbar(QWidget):
+    """Toolbar widget for browsing and selecting directories"""
+    
+    directory_changed = Signal(Path)  # Emitted when a new directory is selected
+    
+    def __init__(self, initial_directory: Path, parent=None):
+        """
+        Initialize the directory toolbar
+        
+        Args:
+            initial_directory: Initial directory path to display
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self.current_directory = initial_directory
+        self._init_ui()
+    
+    def _init_ui(self):
+        """Initialize the user interface"""
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+        
+        # Read-only line edit showing current path
+        self.path_field = QLineEdit()
+        self.path_field.setReadOnly(True)
+        self.path_field.setText(str(self.current_directory))
+        self.path_field.setPlaceholderText("No directory selected")
+        
+        # Browse button with folder icon
+        self.browse_button = QPushButton("Browse...")
+        self.browse_button.setToolTip("Select a directory to browse")
+        self.browse_button.clicked.connect(self._on_browse_clicked)
+        
+        # Add widgets to layout
+        layout.addWidget(self.path_field, stretch=1)
+        layout.addWidget(self.browse_button)
+    
+    def _on_browse_clicked(self):
+        """Handle browse button click - open directory selection dialog"""
+        # Open directory selection dialog
+        selected_dir = QFileDialog.getExistingDirectory(
+            self,
+            "Select Directory",
+            str(self.current_directory),
+            QFileDialog.Option.ShowDirsOnly | QFileDialog.Option.DontResolveSymlinks
+        )
+        
+        if selected_dir:
+            new_path = Path(selected_dir)
+            if new_path != self.current_directory:
+                self.set_directory(new_path)
+                self.directory_changed.emit(new_path)
+    
+    def set_directory(self, directory: Path):
+        """
+        Set the current directory and update the display
+        
+        Args:
+            directory: New directory path
+        """
+        self.current_directory = directory
+        self.path_field.setText(str(directory))
+    
+    def get_directory(self) -> Path:
+        """
+        Get the current directory
+        
+        Returns:
+            Current directory path
+        """
+        return self.current_directory


### PR DESCRIPTION
This pull request introduces a new `DirectoryToolbar` widget to improve directory selection and browsing in the application, and refactors the startup logic to work with directories rather than individual image files. The changes enhance the user experience by allowing users to select a directory containing images, both at startup and from the main window UI.

**Directory Selection & UI Improvements**
* Added the `DirectoryToolbar` widget (`geosetter_lite/ui/directory_toolbar.py`) for browsing and selecting directories, and integrated it into the main window above the image table. This widget emits a signal when the directory changes, triggering image reloads. [[1]](diffhunk://#diff-f7e21a004d05c6a60c5658fce59f4592648596b0f7d79a91be8d9a52d71146a1R1-R80) [[2]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18R117-R128) [[3]](diffhunk://#diff-c576b39a3dd903f0aa04c9ec40a170f62ce7844f407c739099ecb90ce1ceed18L202-R219)
* Updated the main window logic to respond to directory changes via the toolbar, clearing selection and reloading images when a new directory is chosen.

**Startup and Command-Line Refactor**
* Refactored startup logic in `main.py` to prompt for a directory (instead of a single image file) via command-line argument or a directory selection dialog. If a file is provided, its parent directory is used. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L29-R34) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L44-R44) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L56-R92) [[4]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L104-L113)

**Development Environment**
* Updated the `Makefile` to allow passing arguments to the application via the `ARGS` variable for more flexible development and testing.